### PR TITLE
add classifier section in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,14 @@ setup(
     packages=['pyfakewebcam',],
     install_requires = [
         'numpy'
-    ]
+    ],
+    classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
 )


### PR DESCRIPTION
If we add a classifier section to setup.py then maybe dependency management services like pyup.io would recognize this module as Python 3 compatible if you were to republish it.

Appreciate your work!