### PR TITLE
Support for YUV raw video infinity loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# video
+*.yuv

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ If your goal is to run at 30Hz (or slower) and ~26 milliseconds of
 delay is acceptable in your application, then opencv may not be
 necessary. 
 
+For YUV input, the delay should be trivial since no calculation 
+is done.
+
 ## usage 
 
 Insert the v4l2loopback kernel module.
@@ -54,7 +57,7 @@ Insert the v4l2loopback kernel module.
 modprobe v4l2loopback devices=2 # will create two fake webcam devices
 ```
 
-Example code.
+Example RGB code.
 
 ```python
 # see red_blue.py in the examples dir
@@ -83,3 +86,5 @@ Run the following command to see the output of the fake webcam.
 ```
 ffplay /dev/video1
 ```
+
+Example YUV in '/examples/raw_yuv.py'

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,0 +1,6 @@
+# Examples
+* All examples assume '/dev/video1' exists.
+## raw_yuv.py
+* You need to download and unzip a sample mini YUV sequence 
+(176x144x300 frames) from [here](http://trace.eas.asu.edu/yuv/akiyo/akiyo_qcif.7z).
+* More samples can be found [here](http://trace.eas.asu.edu/yuv/).

--- a/examples/raw_yuv.py
+++ b/examples/raw_yuv.py
@@ -1,0 +1,6 @@
+import pyfakewebcam
+
+cam = pyfakewebcam.FakeWebcam('/dev/video1', 176, 144)
+
+while 1:
+	cam.schedule_yuv('akiyo_qcif.yuv', fps=15)


### PR DESCRIPTION
Hi John Emmons, 

Thanks for providing this lib. Practically speaking being able to play raw yuv loop infinitely is super useful for simulated environment for chrome and skype, and GStreamer is surprisingly buggy for this. See [issue](https://github.com/umlaeute/v4l2loopback/issues/189), [issue](https://github.com/umlaeute/v4l2loopback/issues/174) and [issues](https://github.com/umlaeute/v4l2loopback/issues/213).

I am one of the guy in media computation who is annoyed by how new version of GStreamer is incompatible with v4l2loopback. I am tired of GStreamer and I just found your wrapper simple and helpful. So I modified it a little to add a support for infinitely loop yuv video files.

Being able to loop over RGB sequences is important, but also a lot more people want to play YUV sequences directly, without performance loss.

Thanks,

Xu